### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: '3.9'
 services:
   headlesschrome:
     container_name: HeadlessShell
-    image: niniyas:headless-shell:latest
+    image: niniyas/headless-shell:latest
     ports:
       - 9222:9222
 ```


### PR DESCRIPTION
Minor typo in line 21 of the docker-compose.yml sample, it should be "niniyas/headless-shell:latest" instead of "niniyas:headless-shell:latest"